### PR TITLE
Diagnostic pattern change

### DIFF
--- a/DestinationDeepSpace/src/main/java/frc/robot/Robot.java
+++ b/DestinationDeepSpace/src/main/java/frc/robot/Robot.java
@@ -221,8 +221,6 @@ public class Robot extends TimedRobot {
   public void teleopInit() {
     driveSubsystem.startIdle();
     scoringSubsystem.startIdle();
-
-    MotorTestModes.init();
   }
 
   /**
@@ -245,7 +243,13 @@ public class Robot extends TimedRobot {
   public void testInit() {
     // !!!!!! DON'T START THE SS IDLE COMMANDS HERE !!!!
 
-    scoringSubsystem.diagnosticsInit();
+    driveSubsystem.diagnosticsInitialize();
+    climberSubsystem.diagnosticsInitialize();
+    scoringSubsystem.diagnosticsInitialize();
+    navigationSubsystem.diagnosticsInitialize();
+    visionSubsystem.diagnosticsInitialize();
+    lightingSubsystem.diagnosticsInitialize();    
+
     MotorTestModes.init();
   }  
   
@@ -254,8 +258,16 @@ public class Robot extends TimedRobot {
    */
   @Override
   public void testPeriodic() {
-    scoringSubsystem.diagnosticsExecute();
+    
+    driveSubsystem.diagnosticsPeriodic();
+    climberSubsystem.diagnosticsPeriodic();
+    scoringSubsystem.diagnosticsPeriodic();
+    navigationSubsystem.diagnosticsPeriodic();
+    visionSubsystem.diagnosticsPeriodic();
+    lightingSubsystem.diagnosticsPeriodic();    
+
     MotorTestModes.periodic();
+
     // NOTE: because this code executes before robotPeriodic in each iteration
     // the actions here occur BEFORE the scheduled commands run; this means that
     // commands can be added during this execution cycle and will be acted upon

--- a/DestinationDeepSpace/src/main/java/frc/robot/shuffleboard.json
+++ b/DestinationDeepSpace/src/main/java/frc/robot/shuffleboard.json
@@ -10,7 +10,7 @@
         "hgap": 16.0,
         "vgap": 16.0,
         "tiles": {
-          "5,0": {
+          "7,0": {
             "size": [
               6,
               4
@@ -23,7 +23,7 @@
               "Visuals/Show velocity vectors": true
             }
           },
-          "11,1": {
+          "13,1": {
             "size": [
               4,
               1
@@ -34,7 +34,7 @@
               "_title": "SmartDashboard/DriveSubsystem/Turn Joystick Scale"
             }
           },
-          "11,0": {
+          "13,0": {
             "size": [
               4,
               1
@@ -45,7 +45,7 @@
               "_title": "SmartDashboard/DriveSubsystem/Forward Joystick Scale"
             }
           },
-          "5,4": {
+          "7,4": {
             "size": [
               6,
               1
@@ -56,7 +56,7 @@
               "_title": "SmartDashboard/DriveSubsystem/Drive Style"
             }
           },
-          "22,0": {
+          "5,0": {
             "size": [
               1,
               1
@@ -67,7 +67,7 @@
               "_title": "/SmartDashboard/DriveSubsystem/PeriodicCounter"
             }
           },
-          "21,1": {
+          "5,1": {
             "size": [
               2,
               2
@@ -78,7 +78,7 @@
               "_title": "SmartDashboard/DriveSubsystem/TelemetryEnabled"
             }
           },
-          "21,3": {
+          "5,3": {
             "size": [
               2,
               2
@@ -89,9 +89,9 @@
               "_title": "SmartDashboard/DriveSubsystem/DiagnosticsEnabled"
             }
           },
-          "11,3": {
+          "13,3": {
             "size": [
-              9,
+              7,
               3
             ],
             "content": {
@@ -102,9 +102,9 @@
               "Visible data/SmartDashboard/DriveSubsystem/Speed Factor": true
             }
           },
-          "11,6": {
+          "13,6": {
             "size": [
-              9,
+              7,
               3
             ],
             "content": {
@@ -115,7 +115,7 @@
               "Visible data/SmartDashboard/DriveSubsystem/Turn Factor": true
             }
           },
-          "15,0": {
+          "17,0": {
             "size": [
               3,
               1
@@ -194,7 +194,7 @@
         "hgap": 16.0,
         "vgap": 16.0,
         "tiles": {
-          "22,0": {
+          "5,0": {
             "size": [
               1,
               1
@@ -205,7 +205,7 @@
               "_title": "/SmartDashboard/NavigationSubsystem/PeriodicCounter"
             }
           },
-          "21,1": {
+          "5,1": {
             "size": [
               2,
               2
@@ -216,7 +216,7 @@
               "_title": "SmartDashboard/NavigationSubsystem/TelemetryEnabled"
             }
           },
-          "21,3": {
+          "5,3": {
             "size": [
               2,
               2
@@ -227,7 +227,7 @@
               "_title": "SmartDashboard/NavigationSubsystem/DiagnosticsEnabled"
             }
           },
-          "5,1": {
+          "7,1": {
             "size": [
               5,
               3
@@ -240,7 +240,7 @@
               "Visible data/SmartDashboard/NavigationSubsystem/Yaw Angle (deg)": true
             }
           },
-          "5,4": {
+          "7,4": {
             "size": [
               5,
               3
@@ -266,7 +266,7 @@
         "hgap": 16.0,
         "vgap": 16.0,
         "tiles": {
-          "22,0": {
+          "5,0": {
             "size": [
               1,
               1
@@ -299,7 +299,7 @@
               "_title": "/SmartDashboard/ScoringSubsystem/Arm Ticks"
             }
           },
-          "21,1": {
+          "5,1": {
             "size": [
               2,
               2
@@ -310,7 +310,7 @@
               "_title": "SmartDashboard/ScoringSubsystem/TelemetryEnabled"
             }
           },
-          "21,3": {
+          "5,3": {
             "size": [
               2,
               2
@@ -319,6 +319,17 @@
               "_type": "Toggle Switch",
               "_source0": "network_table:///SmartDashboard/ScoringSubsystem/DiagnosticsEnabled",
               "_title": "SmartDashboard/ScoringSubsystem/DiagnosticsEnabled"
+            }
+          },
+          "7,0": {
+            "size": [
+              3,
+              1
+            ],
+            "content": {
+              "_type": "Text View",
+              "_source0": "network_table:///SmartDashboard/ScoringSubsystem/CurrentCommand",
+              "_title": "SmartDashboard/ScoringSubsystem/CurrentCommand"
             }
           }
         }
@@ -334,7 +345,7 @@
         "hgap": 16.0,
         "vgap": 16.0,
         "tiles": {
-          "5,0": {
+          "7,0": {
             "size": [
               11,
               7
@@ -353,7 +364,7 @@
               "imageHeight": -1
             }
           },
-          "22,0": {
+          "5,0": {
             "size": [
               1,
               1
@@ -364,7 +375,7 @@
               "_title": "SmartDashboard/VisionSubsystem/PeriodicCounter"
             }
           },
-          "21,1": {
+          "5,1": {
             "size": [
               2,
               2
@@ -375,7 +386,7 @@
               "_title": "SmartDashboard/VisionSubsystem/TelemetryEnabled"
             }
           },
-          "21,3": {
+          "5,3": {
             "size": [
               2,
               2
@@ -399,7 +410,7 @@
         "hgap": 16.0,
         "vgap": 16.0,
         "tiles": {
-          "22,0": {
+          "5,0": {
             "size": [
               1,
               1
@@ -438,7 +449,7 @@
               "Slider Settings/Block increment": 1.0
             }
           },
-          "21,3": {
+          "5,3": {
             "size": [
               2,
               2
@@ -449,7 +460,7 @@
               "_title": "SmartDashboard/ClimberSubsystem/DiagnosticsEnabled"
             }
           },
-          "21,1": {
+          "5,1": {
             "size": [
               2,
               2
@@ -473,7 +484,7 @@
         "hgap": 16.0,
         "vgap": 16.0,
         "tiles": {
-          "22,0": {
+          "5,0": {
             "size": [
               1,
               1
@@ -484,7 +495,7 @@
               "_title": "/SmartDashboard/LightingSubsystem/PeriodicCounter"
             }
           },
-          "5,0": {
+          "7,0": {
             "size": [
               7,
               1
@@ -495,7 +506,7 @@
               "_title": "/SmartDashboard/LightingControl/Status"
             }
           },
-          "12,0": {
+          "14,0": {
             "size": [
               3,
               1
@@ -506,7 +517,7 @@
               "_title": "SmartDashboard/LightingControl/ConnectionAttempts"
             }
           },
-          "21,1": {
+          "5,1": {
             "size": [
               2,
               2
@@ -517,7 +528,7 @@
               "_title": "SmartDashboard/LightingSubsystem/TelemetryEnabled"
             }
           },
-          "21,3": {
+          "5,3": {
             "size": [
               2,
               2

--- a/DestinationDeepSpace/src/main/java/frc/robot/subsystem/BitBucketSubsystem.java
+++ b/DestinationDeepSpace/src/main/java/frc/robot/subsystem/BitBucketSubsystem.java
@@ -78,12 +78,17 @@ public abstract class BitBucketSubsystem extends Subsystem {
 		}
 		return diagnosticsEnabled;
 	}
+	public void clearDiagnosticsEnabled()
+	{
+		diagnosticsEnabled = false;
+		SmartDashboard.putBoolean(getName() + "/DiagnosticsEnabled", diagnosticsEnabled);
+	}
 
 	public abstract void initialize();		// Force all derived classes to have these interfaces
 
-	public abstract void diagnosticsInit();
+	public abstract void diagnosticsInitialize();
 	
-	public abstract void diagnosticsExecute();
+	public abstract void diagnosticsPeriodic();
 	
 	public abstract void diagnosticsCheck();
 	

--- a/DestinationDeepSpace/src/main/java/frc/robot/subsystem/climber/ClimberSubsystem.java
+++ b/DestinationDeepSpace/src/main/java/frc/robot/subsystem/climber/ClimberSubsystem.java
@@ -67,6 +67,9 @@ public class ClimberSubsystem extends BitBucketSubsystem {
 
 	@Override
 	public void periodic() {
+		clearDiagnosticsEnabled();
+		updateBaseDashboard();
+
 		switch (state) {
 			case IDLE:{
 				if (oi.armClimber()){
@@ -97,24 +100,27 @@ public class ClimberSubsystem extends BitBucketSubsystem {
 				break;
 		}
 
-		updateBaseDashboard();
-
 		if (getTelemetryEnabled())
 		{
 		}
+		updateDashboard();
+		
+	}
+
+	@Override
+	public void diagnosticsPeriodic() {
+		updateBaseDashboard();
 		if (getDiagnosticsEnabled())
 		{
 			double angle = SmartDashboard.getNumber(getName()+"/ServoTestAngle(deg)", 0.0);
 			climbServo.setAngle(angle);
 		}
-		SmartDashboard.putNumber(getName()+"/CurrentServoAngle(deg)",climbServo.getAngle());
-		
+		updateDashboard();
 	}
 
-	@Override
-	public void diagnosticsExecute() {
-		// TODO: Auto-generated method stub
-		
+	public void updateDashboard()
+	{
+		SmartDashboard.putNumber(getName()+"/CurrentServoAngle(deg)",climbServo.getAngle());
 	}
 
 	public void initialize() {
@@ -129,7 +135,7 @@ public class ClimberSubsystem extends BitBucketSubsystem {
 	}
 
 	@Override
-	public void diagnosticsInit() {
+	public void diagnosticsInitialize() {
 
 	}
 

--- a/DestinationDeepSpace/src/main/java/frc/robot/subsystem/drive/Diagnostics.java
+++ b/DestinationDeepSpace/src/main/java/frc/robot/subsystem/drive/Diagnostics.java
@@ -29,7 +29,7 @@ public class Diagnostics extends Command {
 
     // Called just before this Command runs the first time
     protected void initialize() {
-    	driveSubsystem.diagnosticsInit();
+    	driveSubsystem.diagnosticsInitialize();
     	System.out.println("Entering Drive Diagnostics");
     }
 
@@ -37,7 +37,7 @@ public class Diagnostics extends Command {
     protected void execute() {
     	System.out.println("Executing Drive Diagnostics");
     	if(diagInitLoops < driveSubsystem.DIAG_LOOPS_RUN) {
-    		driveSubsystem.diagnosticsExecute();
+    		driveSubsystem.diagnosticsPeriodic();
     		diagInitLoops++;
     	}
     }

--- a/DestinationDeepSpace/src/main/java/frc/robot/subsystem/drive/DriveSubsystem.java
+++ b/DestinationDeepSpace/src/main/java/frc/robot/subsystem/drive/DriveSubsystem.java
@@ -732,18 +732,41 @@ public class DriveSubsystem extends BitBucketSubsystem {
 	
 	@Override
 	public void periodic() {
-
+		clearDiagnosticsEnabled();
 		updateBaseDashboard();
 		if (getTelemetryEnabled())
 		{
 
 		}
+	}
+	/* Any hardware devices used in this subsystem must
+	*  have a check here to see if it is still connected and 
+	*  working properly. For motors check for current draw.
+	*  Return true iff all devices are working properly. Otherwise
+	*  return false. This sets all motors to percent output
+	*/
+	@Override
+	public void diagnosticsInitialize() {
+		
+	}
+	
+	@Override
+	public void diagnosticsPeriodic() {
+
+		updateBaseDashboard();
 		if (getDiagnosticsEnabled())
 		{
+		/// TODO: Add new diagnostics for this subsystem
 
 		}		
+
 	}
-  	
+	
+	@Override
+	public void diagnosticsCheck() {
+		/* Reset flag */
+		
+	}  	
 	public void disable() {
 		setAllMotorsZero();
 	}
@@ -902,35 +925,6 @@ public class DriveSubsystem extends BitBucketSubsystem {
 		setPosition(rightFrontMotor, inchesToNativeTicks(value_inches));
 	}
 	
-	/* Any hardware devices used in this subsystem must
-	*  have a check here to see if it is still connected and 
-	*  working properly. For motors check for current draw.
-	*  Return true iff all devices are working properly. Otherwise
-	*  return false. This sets all motors to percent output
-	*/
-	@Override
-	public void diagnosticsInit() {
-		
-	}
-	
-	@Override
-	public void diagnosticsExecute() {
-
-		/* Init Diagnostics */
-		SmartDashboard.putBoolean(getName()+"/RunningDiag", true);
-		
-		rightFrontMotor.set(ControlMode.PercentOutput, DriveConstants.MOTOR_TEST_PERCENT);
-		rightRearMotor.set(ControlMode.PercentOutput, -DriveConstants.MOTOR_TEST_PERCENT);
-		leftFrontMotor.set(ControlMode.PercentOutput, -DriveConstants.MOTOR_TEST_PERCENT);
-		leftRearMotor.set(ControlMode.PercentOutput, DriveConstants.MOTOR_TEST_PERCENT);
-	}
-	
-	@Override
-	public void diagnosticsCheck() {
-		/* Reset flag */
-		
-	}
-
 	// Move is complete when we are within tolerance and can consider starting the next move
 	public boolean isMoveComplete(double distance_inches)	// At timeout should be used with this
 	{

--- a/DestinationDeepSpace/src/main/java/frc/robot/subsystem/lighting/LightingSubsystem.java
+++ b/DestinationDeepSpace/src/main/java/frc/robot/subsystem/lighting/LightingSubsystem.java
@@ -114,10 +114,37 @@ public class LightingSubsystem extends BitBucketSubsystem {
 			   500) ; 			// period_msec - nice default
 	}
 
-
-  	@Override
-	public void diagnosticsInit() {
+	@Override
+	protected void initDefaultCommand() {
 		// TODO Auto-generated method stub
+		
+	}
+
+	@Override
+	public void periodic() {
+		clearDiagnosticsEnabled();		
+		updateBaseDashboard();
+		if (getTelemetryEnabled())
+		{
+			
+		}
+		
+	}
+
+
+	@Override
+	public void diagnosticsInitialize() {
+		// TODO Auto-generated method stub
+		
+	}
+
+	@Override
+	public void diagnosticsPeriodic() {
+		updateBaseDashboard();
+		if (getDiagnosticsEnabled())
+		{
+			
+		}
 		
 	}
 
@@ -127,31 +154,6 @@ public class LightingSubsystem extends BitBucketSubsystem {
 		
 	}
 	
-	@Override
-	protected void initDefaultCommand() {
-		// TODO Auto-generated method stub
-		
-	}
-
-	@Override
-	public void periodic() {
-		updateBaseDashboard();
-		if (getTelemetryEnabled())
-		{
-			
-		}
-		if (getDiagnosticsEnabled())
-		{
-			
-		}
-		
-	}
-
-	@Override
-	public void diagnosticsExecute() {
-		// TODO Auto-generated method stub
-		
-	}
 
 	@Override
 	public void initialize() {

--- a/DestinationDeepSpace/src/main/java/frc/robot/subsystem/navigation/NavigationSubsystem.java
+++ b/DestinationDeepSpace/src/main/java/frc/robot/subsystem/navigation/NavigationSubsystem.java
@@ -49,7 +49,7 @@ public class NavigationSubsystem extends BitBucketSubsystem {
 	}
 
   	@Override
-	public void diagnosticsInit() {
+	public void diagnosticsInitialize() {
 		// TODO Auto-generated method stub
 		
 	}
@@ -73,6 +73,7 @@ public class NavigationSubsystem extends BitBucketSubsystem {
 
 	@Override
 	public void periodic() {
+		clearDiagnosticsEnabled();		
 		updateBaseDashboard();
 		if (getTelemetryEnabled())
 		{
@@ -87,7 +88,7 @@ public class NavigationSubsystem extends BitBucketSubsystem {
 	}
 
 	@Override
-	public void diagnosticsExecute() {
+	public void diagnosticsPeriodic() {
 		// TODO Auto-generated method stub
 		
 	}

--- a/DestinationDeepSpace/src/main/java/frc/robot/subsystem/scoring/ScoringSubsystem.java
+++ b/DestinationDeepSpace/src/main/java/frc/robot/subsystem/scoring/ScoringSubsystem.java
@@ -231,21 +231,6 @@ public class ScoringSubsystem extends BitBucketSubsystem {
 	public int getArmLevelTickError() {
 		return rotationMotor1.getClosedLoopError();
 	}
-
-
-
-
-
-  	@Override
-	public void diagnosticsInit() {
-		// TODO Auto-generated method stub
-	}
-
-	@Override
-	public void diagnosticsCheck() {
-		// TODO Auto-generated method stub
-		
-	}
 	
 	@Override
 	protected void initDefaultCommand() {
@@ -264,11 +249,23 @@ public class ScoringSubsystem extends BitBucketSubsystem {
 
 	@Override
 	public void periodic() {
+		clearDiagnosticsEnabled();
 		updateBaseDashboard();
 		if (getTelemetryEnabled()) {
 			SmartDashboard.putNumber(getName() + "/Arm Angle", getAngle());
 			SmartDashboard.putNumber(getName() + "/Arm Ticks", rotationMotor1.getSelectedSensorPosition());
 		}
+		// commands will handle dealing with arm manipulation
+	}
+
+	@Override
+	public void diagnosticsInitialize() {
+		// TODO Auto-generated method stub
+	}
+
+	@Override
+	public void diagnosticsPeriodic() {
+		updateBaseDashboard();
 		if (getDiagnosticsEnabled())
 		{
 			double angle = SmartDashboard.getNumber(getName() + "/Test Angle", 0);
@@ -276,23 +273,17 @@ public class ScoringSubsystem extends BitBucketSubsystem {
 		}
 
 		manualArmOperate();
-
-
-		// commands will handle dealing with arm manipulation
 	}
 
 	@Override
-	public void diagnosticsExecute() {
+	public void diagnosticsCheck() {
 		// TODO Auto-generated method stub
-
-		//ScoringDiagnostics.periodic();
+		
 	}
 
 	@Override
 	public void initialize() {
 		initializeBaseDashboard();
-
-
 
 		SmartDashboard.putNumber(getName() + "/Test Angle", 0);
 	}

--- a/DestinationDeepSpace/src/main/java/frc/robot/subsystem/vision/VisionSubsystem.java
+++ b/DestinationDeepSpace/src/main/java/frc/robot/subsystem/vision/VisionSubsystem.java
@@ -43,18 +43,6 @@ public class VisionSubsystem extends BitBucketSubsystem {
 
 	private LightingSubsystem lightingSubsystem = LightingSubsystem.instance();
 
-  	@Override
-	public void diagnosticsInit() {
-		// TODO Auto-generated method stub
-		
-	}
-
-	@Override
-	public void diagnosticsCheck() {
-		// TODO Auto-generated method stub
-		
-	}
-	
 	@Override
 	protected void initDefaultCommand() {
 		// TODO Auto-generated method stub
@@ -63,6 +51,7 @@ public class VisionSubsystem extends BitBucketSubsystem {
 
 	@Override
 	public void periodic() {
+		clearDiagnosticsEnabled();		
 		if (ds.isDisabled())
 		{
 			setIlluminatorSnore();
@@ -81,14 +70,27 @@ public class VisionSubsystem extends BitBucketSubsystem {
 		{
 			
 		}
-		if (getDiagnosticsEnabled())
-		{
-			
-		}			
 	}
 
 	@Override
-	public void diagnosticsExecute() {
+	public void diagnosticsInitialize() {
+		// TODO Auto-generated method stub
+	}
+
+	@Override
+	public void diagnosticsPeriodic() {
+		updateBaseDashboard();
+		if (getDiagnosticsEnabled())
+		{
+
+			/// TODO: Add controls for illuminator on/off and camera controls here
+		}
+
+
+	}
+
+	@Override
+	public void diagnosticsCheck() {
 		// TODO Auto-generated method stub
 		
 	}


### PR DESCRIPTION
diagnostics flag (independent on each subsystem) is forced clear on teleop and auto; only able to engage diagnostics in test mode and individually for each subsystem. Dashboard updates now count in test mode.