### PR TITLE
Fixed AutoTuner troubles, new WPILib update

### DIFF
--- a/DestinationDeepSpace/build.gradle
+++ b/DestinationDeepSpace/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id "java"
     id "idea"
-    id "edu.wpi.first.GradleRIO" version "2019.1.1"
+    id "edu.wpi.first.GradleRIO" version "2019.2.1"
     id "com.snobot.simulator.plugin.SnobotSimulatorPlugin" version "2019-0.2.0" apply false
 }
 

--- a/DestinationDeepSpace/src/main/java/frc/robot/utils/autotuner/TunerConstants.java
+++ b/DestinationDeepSpace/src/main/java/frc/robot/utils/autotuner/TunerConstants.java
@@ -31,7 +31,7 @@ public class TunerConstants {
 	 * set to zero to skip waiting for confirmation, set to nonzero to wait and
 	 * report to DS if action fails.
 	 */
-    public static final int kTimeoutMs = 30;
+    public static final int kTimeoutMs = 0;
     
 
 

--- a/DestinationDeepSpace/src/main/java/frc/robot/utils/autotuner/steps/TuningStep.java
+++ b/DestinationDeepSpace/src/main/java/frc/robot/utils/autotuner/steps/TuningStep.java
@@ -170,10 +170,16 @@ public abstract class TuningStep {
 
     /** Put some data on the Dashboard */
     private void put(int error, int position, int velocity, double power) {
-        SmartDashboard.putNumber(TunerConstants.ERROR_KEY,    error);
-        SmartDashboard.putNumber(TunerConstants.POSITION_KEY, position);
-        SmartDashboard.putNumber(TunerConstants.VELOCITY_KEY, velocity);
-        SmartDashboard.putNumber(TunerConstants.POWER_KEY,    power);
+        // make sure the Dashboard adds the values while they
+        // accurately represent the data
+        // (Dashboard does not update if you put the same value as
+        // it was before)
+        double epsilon = Math.random() * 0.0001;
+
+        SmartDashboard.putNumber(TunerConstants.ERROR_KEY,    error + epsilon);
+        SmartDashboard.putNumber(TunerConstants.POSITION_KEY, position + epsilon);
+        SmartDashboard.putNumber(TunerConstants.VELOCITY_KEY, velocity + epsilon);
+        SmartDashboard.putNumber(TunerConstants.POWER_KEY,    power + epsilon);
     }
 
 


### PR DESCRIPTION
- Fixed problem where MotionMagic didn't work (cruise velocity was set in PercentOutput mode which makes no sense, so no cruise velocity was given when we were in MotionMagic)
- Since the Dashboard will only update a graph if new different data was added, I added a small degree of randomness to the data we add to the Dashboard so different data is added every time - causing it to update - but it isn't a noticeable difference. DataWindow data remains the same
- Removed timeout on AutoTuner, it just slows it down